### PR TITLE
[DATA-515] Add check separate before hard code removal of 2nd br drop

### DIFF
--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -198,10 +198,11 @@ class Sanitizer(object):
                         element.text)
 
             elif element.tag == 'br':
-                nx = element.getnext()
-                if nx is not None and nx.tag == 'br' and not element.tail:
-                    nx.drop_tag()
-                    continue
+                if 'br' not in self.separate:
+                    nx = element.getnext()
+                    if nx is not None and nx.tag == 'br' and not element.tail:
+                        nx.drop_tag()
+                        continue
 
                 # Drop <br/>'s at the beginning of parents.
                 parent = element.getparent()


### PR DESCRIPTION
The 'separate' set in the setting configuration defined what tags can be repeated back to back.
For the 'br' tag. this not work because the custom handling for it does not check the values in 'separate'.

I added the 'separate' check in the 'br' custom handling to allow for the required double 'br' tags.