### PR TITLE
[Data 515] br dropped as first items in parent tag

### DIFF
--- a/html_sanitizer/__init__.py
+++ b/html_sanitizer/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 
-VERSION = (1, 3, 3)
+VERSION = (1, 3, 4)
 __version__ = '.'.join(map(str, VERSION))
 
 

--- a/html_sanitizer/__init__.py
+++ b/html_sanitizer/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 
-VERSION = (1, 3, 0)
+VERSION = (1, 3, 3)
 __version__ = '.'.join(map(str, VERSION))
 
 

--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -62,6 +62,7 @@ DEFAULT_SETTINGS = {
         'sup',
         'hr',
     },
+    'allowed_first_tags': set(),
     'attributes': {
         'a': ('href', 'name', 'target', 'title', 'id'),
     },
@@ -208,10 +209,11 @@ class Sanitizer(object):
                 parent = element.getparent()
                 if (parent is not None and
                         element.getprevious() is None and
+                        'br' not in self.allowed_first_tags and
                         whitespace_re.match(parent.text or '')):  # noqa
                     element.drop_tag()
 
-            if not element.text:
+            if not element.text and 'br' not in self.allowed_first_tags:
                 first = list(element)[0] if list(element) else None
                 if first is not None and first.tag == 'br':
                     first.drop_tag()

--- a/html_sanitizer/sanitizer.py
+++ b/html_sanitizer/sanitizer.py
@@ -198,10 +198,11 @@ class Sanitizer(object):
                         element.text)
 
             elif element.tag == 'br':
-                nx = element.getnext()
-                if nx is not None and nx.tag == 'br' and not element.tail:
-                    nx.drop_tag()
-                    continue
+                if 'br' not in self.separate:
+                    nx = element.getnext()
+                    if nx is not None and nx.tag == 'br' and not element.tail:
+                        nx.drop_tag()
+                        continue
 
                 # Drop <br/>'s at the beginning of parents.
                 parent = element.getparent()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
     author='Matthias Kestenholz',
     author_email='mk@feinheit.ch',
-    url='https://github.com/matthiask/html-sanitizer/',
+    url='https://github.com/RealMassive/html-sanitizer/',
     license='BSD License',
     platforms=['OS Independent'],
     packages=find_packages(),


### PR DESCRIPTION
Added 'allowed_first_tags' variable to configuration and processing to allow br tags at first location within an enclosing tag